### PR TITLE
Add Jest setup and test for product routes

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "scripts": {
     "start": "nodemon server.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "keywords": [],
   "author": "",
@@ -21,6 +21,8 @@
     "mongoose": "^8.8.1"
   },
   "devDependencies": {
-    "nodemon": "^3.1.7"
+    "nodemon": "^3.1.7",
+    "jest": "^29.7.0",
+    "supertest": "^6.3.4"
   }
 }

--- a/backend/tests/productRoutes.test.js
+++ b/backend/tests/productRoutes.test.js
@@ -1,0 +1,24 @@
+const request = require('supertest');
+const express = require('express');
+
+// Mock Product model
+jest.mock('../models/Product', () => ({
+  find: jest.fn(),
+}));
+
+const Product = require('../models/Product');
+const productRoutes = require('../routes/productRoutes');
+
+const app = express();
+app.use(express.json());
+app.use('/api/products', productRoutes);
+
+describe('GET /api/products', () => {
+  it('returns status 200 and an array', async () => {
+    Product.find.mockResolvedValue([]);
+    const res = await request(app).get('/api/products');
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add Jest and SuperTest dev dependencies
- configure `npm test` script
- create basic test verifying `GET /api/products`

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68786808fa28832f9a1bec5095510b2f